### PR TITLE
Adds dummy test

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/aceleradora-TW/sistema-de-votacao/issues"
   },
   "homepage": "https://github.com/aceleradora-TW/sistema-de-votacao#readme",
+  "jest": {
+    "testEnvironment": "node"
+  },
   "devDependencies": {
     "jest": "^22.4.3",
     "nodemon": "^1.17.2"

--- a/test/hello-word.test.js
+++ b/test/hello-word.test.js
@@ -1,0 +1,4 @@
+
+it('prevents tests from failing', () => {
+  expect('Hello').toBe('Hello')
+})


### PR DESCRIPTION
This test was added to unblock the pipeline for now.

By default, Jest will fail when there are no tests to be run. Instead of
changing this behavior, it makes more sense to write a dummy temporary test.