### PR TITLE
Eslintignore dist.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
-public/dist.js
-/node_modules
+src/public/dist.js
+node_modules/


### PR DESCRIPTION
O caminho do `dist.js` foi movido. Faltou atualizar o `eslintignore`.